### PR TITLE
[pileup_encoder] fix pileup position indexing from bam file

### DIFF
--- a/variantworks/sample_encoder.py
+++ b/variantworks/sample_encoder.py
@@ -191,9 +191,11 @@ class PileupEncoder(SampleEncoder):
 
         bam = self.bams[bam_file]
 
-        # Get pileups from BAM
+        # Get pileups from BAM.
+        # Note that VCF positions are 1 based, but pysam pileup regions are 0 based.
+        # So subtract one from position.
         pileups = bam.pileup(chrom,
-                             variant_pos, variant_pos + 1,
+                             variant_pos - 1, variant_pos,
                              truncate=True,
                              max_depth=self.max_reads)
 


### PR DESCRIPTION
VCF has position in a 1-based indexing, whereas pysam pileup are 0 based indexing. This was causing a mismatch in column number when creating pileups.