### PR TITLE
[SDK] Change utils.py filename into exceptions.py and place it under 'utils' package

### DIFF
--- a/variantworks/io/vcfio.py
+++ b/variantworks/io/vcfio.py
@@ -25,7 +25,7 @@ from functools import partial
 
 from variantworks.io.baseio import BaseReader
 from variantworks.types import VariantZygosity, VariantType, Variant
-from variantworks.utils import extend_exception
+from variantworks.utils.exceptions import extend_exception
 
 
 class VCFReader(BaseReader):

--- a/variantworks/utils/__init__.py
+++ b/variantworks/utils/__init__.py
@@ -1,0 +1,17 @@
+#
+# Copyright 2020 NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Init file for utils module."""

--- a/variantworks/utils/exceptions.py
+++ b/variantworks/utils/exceptions.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""Utility functions and classes."""
+"""Custom Exceptions."""
 
 
 def extend_exception(e, msg):


### PR DESCRIPTION
Resolving the conflict caused by PR #96 and PR #88, by uniting the `variantworks.utils` package and `variantworks/utils.py` file.
In PR #96 - we added `utils.py` file under `varaitworks` package.
In PR #88 - we added `utils` package under `variantworks` package.
According to https://docs.python.org/3/tutorial/modules.html#the-module-search-path the package name has a higher priority when in the search path, therefore the unit tests were failing  when I merged the master changes into PR #88.
