### PR TITLE
Review of SummaryEncoder

### DIFF
--- a/tests/test_summary_encoder.py
+++ b/tests/test_summary_encoder.py
@@ -26,9 +26,8 @@ from test_utils import get_data_folder
 @pytest.mark.parametrize(
     'base_string,expected_output',
     [
-        ('AAA+1TCA+1TAAaaaaaaaAaa', [['T', 'T'], [False, False]]),
-        ('A+1T+1TAa+1Ga', [['T', 'T', 'G'], [False, False, False]]),
         ('A+1Ta*+1TAa+1Ga', [['T', 'T', 'G'], [False, True, False]]),
+        ('G+1CG+1CG+1CGGG-1NTagg+2gag-1ng-1nggGggGG#', [['C', 'C', 'C', 'ga'], [False, False, False, False]]),
     ],
 )
 def test_find_insertion(base_string, expected_output):

--- a/tests/test_summary_encoder.py
+++ b/tests/test_summary_encoder.py
@@ -23,6 +23,19 @@ from variantworks.encoders import SummaryEncoder
 from test_utils import get_data_folder
 
 
+@pytest.mark.parametrize(
+    'base_string,expected_output',
+    [
+        ('AAA+1TCA+1TAAaaaaaaaAaa', [['T', 'T'], [False, False]]),
+        ('A+1T+1TAa+1Ga', [['T', 'T', 'G'], [False, False, False]]),
+        ('A+1Ta*+1TAa+1Ga', [['T', 'T', 'G'], [False, True, False]]),
+    ],
+)
+def test_find_insertion(base_string, expected_output):
+    output = SummaryEncoder._find_insertions(base_string)
+    assert all([x == y for x, y in zip(output, expected_output)])
+
+
 def test_counts_correctness():
     region = FileRegion(start_pos=0,
                         end_pos=14460,

--- a/variantworks/encoders.py
+++ b/variantworks/encoders.py
@@ -114,7 +114,7 @@ class SummaryEncoder(Encoder):
                 inserted_bases = base_pileup[insertion_bases_start_idx:insertion_bases_start_idx+insertion_length]
                 insertions.append(inserted_bases)
                 next_to_del.append(True if base_pileup[idx - 1] in '*#' else False)
-                idx = insertion_bases_start_idx + insertion_length
+                idx = insertion_bases_start_idx + insertion_length + 1  # skip the consecutive base after insertion
             else:
                 idx += 1
         return insertions, next_to_del

--- a/variantworks/encoders.py
+++ b/variantworks/encoders.py
@@ -86,7 +86,8 @@ class SummaryEncoder(Encoder):
                         "#",
                         "*"]
 
-    def _find_insertions(self, base_pileup):
+    @staticmethod
+    def _find_insertions(base_pileup):
         """Finds all of the insertions in a given base's pileup string.
 
         Args:
@@ -100,23 +101,20 @@ class SummaryEncoder(Encoder):
         insertions = []
         idx = 0
         next_to_del = []
-        while (idx < len(base_pileup)):
-            if (base_pileup[idx] == "+"):
+        while idx < len(base_pileup):
+            if base_pileup[idx] == "+":
                 end_of_number = False
-                start_index = idx+1
+                insertion_bases_start_idx = idx+1
                 while not end_of_number:
-                    if (base_pileup[start_index].isdigit()):
-                        start_index += 1
+                    if base_pileup[insertion_bases_start_idx].isdigit():
+                        insertion_bases_start_idx += 1
                     else:
                         end_of_number = True
-                insertion_length = int(base_pileup[idx:start_index])
-                inserted_bases = base_pileup[idx+(start_index-idx):idx+(start_index-idx)+insertion_length]
+                insertion_length = int(base_pileup[idx:insertion_bases_start_idx])
+                inserted_bases = base_pileup[insertion_bases_start_idx:insertion_bases_start_idx+insertion_length]
                 insertions.append(inserted_bases)
-                if (base_pileup[idx-1] == "*" or base_pileup[idx-1] == "#"):
-                    next_to_del.append(True)
-                else:
-                    next_to_del.append(False)
-                idx += (start_index-idx) + 1 + insertion_length
+                next_to_del.append(True if base_pileup[idx - 1] in '*#' else False)
+                idx = insertion_bases_start_idx + insertion_length
             else:
                 idx += 1
         return insertions, next_to_del
@@ -159,10 +157,8 @@ class SummaryEncoder(Encoder):
 
             # Keep track of ref and insert positions in the pileup and the insertions
             # in the pileup.
-            ref_insert_pos = []  # ref position for ref base pos in pileup, insert for additional inserted bases
-            ref_insert_pos.append((i, 0))
-            insertions_store = []
-            insertions_store.append([])
+            ref_insert_pos = [(i, 0)]  # ref position for ref base pos in pileup, insert for additional inserted bases
+            insertions_store = [[]]
             for j in range(longest_insertion):
                 ref_insert_pos.append((i, j+1))
                 insertions_store.append(insertions)


### PR DESCRIPTION
Related to PR #89

Fixed [`idx += (start_index-idx) + 1 + insertion_length`](https://github.com/clara-parabricks/VariantWorks/compare/master...ohadmo:omosafi/review-pr-89?expand=1#diff-7cf5da805918a4dcc73861a1572f8300L119). the `+1` is not right, it can actually lead to missed insertions if there are more than one insertion in a subread (it adds up with every insertion in a subread). 

Added unit test for `_find_insertions()`
