### PR TITLE
[summaryencoder] return positions as torch tensor from encoding call

### DIFF
--- a/variantworks/encoders.py
+++ b/variantworks/encoders.py
@@ -93,6 +93,11 @@ class SummaryEncoder(Encoder):
         Args:
             region : Region dataclass specifying region within a pileup to generate
                      an encoding for.
+
+        Returns:
+            (count_matrix, positions) tuple
+            count_matrix : A torch tensor encoding the summary count for the pileup
+            positions : A torch tensor encoding reference and inserted positions in pileup
         """
         assert(isinstance(region, FileRegion))
         start_pos = region.start_pos
@@ -110,6 +115,7 @@ class SummaryEncoder(Encoder):
         positions = calculate_positions(start_pos, end_pos, subreads, truth_coverage,
                                         self._exclude_no_coverage_positions)
 
+        positions = torch.IntTensor(positions)
         # Using positions, calculate pileup counts
         pileup_counts = torch.zeros((len(positions), 10))
         for i in range(len(positions)):
@@ -140,9 +146,9 @@ class SummaryEncoder(Encoder):
                     pileup_counts[i, self.symbols.index(inserted_base)] += 1
 
         if self._normalize_counts:
-            return normalize_counts(pileup_counts, positions)
+            return normalize_counts(pileup_counts, positions), positions
         else:
-            return pileup_counts
+            return pileup_counts, positions
 
 
 class HaploidLabelEncoder(Encoder):

--- a/variantworks/utils/encoders.py
+++ b/variantworks/utils/encoders.py
@@ -111,8 +111,8 @@ def calculate_positions(start_pos, end_pos, subreads, truth_coverage, exclude_no
         # Keep track of ref and insert positions in the pileup and the insertions
         # in the pileup.
         ref_insert_pos = []  # ref position for ref base pos in pileup, insert for additional inserted bases
-        ref_insert_pos.append((i, 0))
+        ref_insert_pos.append([i, 0])
         for j in range(longest_insertion):
-            ref_insert_pos.append((i, j+1))
+            ref_insert_pos.append([i, j+1])
         positions += ref_insert_pos
     return positions


### PR DESCRIPTION
This PR updates the summary encoder to also return the positions as a torch tensor