### PR TITLE
[model] add optional softmax layer to consensus rnn

### DIFF
--- a/docs/source/README.rst
+++ b/docs/source/README.rst
@@ -37,6 +37,7 @@ Getting Started
 
     git clone --recursive https://github.com/clara-parabricks/VariantWorks.git
     cd VariantWorks
+    pip install -r python-style-requirements.txt
     pip install -r requirements.txt
     pip install -e .
     # Install pre-push hooks to run tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,13 +17,11 @@
 bgzip==0.3.3
 biopython==1.78
 cyvcf2==0.20.1
-flake8==3.8.4
 h5py==2.10.0
 nemo-toolkit==0.10.1
 numpy==1.18.3
 matplotlib==3.2.2
 pandas==1.0.1
-pydocstyle==5.0.2
 pysam==0.15.4
 pytest==4.4.1
 pytest-depends==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,11 +17,13 @@
 bgzip==0.3.3
 biopython==1.78
 cyvcf2==0.20.1
+flake8==3.8.4
 h5py==2.10.0
 nemo-toolkit==0.10.1
 numpy==1.18.3
 matplotlib==3.2.2
 pandas==1.0.1
+pydocstyle==5.0.2
 pysam==0.15.4
 pytest==4.4.1
 pytest-depends==1.0.1

--- a/samples/simple_consensus_caller/README.md
+++ b/samples/simple_consensus_caller/README.md
@@ -15,7 +15,7 @@ The pre-processing of files done in this sample depend on several third-party
 softwares. Please make sure you have them available in your environment in the
 `$PATH` variable before continuing with this sample.
 
-1. `minimap2` >= 2.0
+1. `minimap2` >= 2.17
 2. `samtools` >= 1.10
 
 ## Data Generation

--- a/samples/simple_consensus_caller/rnn_consensus_infer.py
+++ b/samples/simple_consensus_caller/rnn_consensus_infer.py
@@ -31,7 +31,7 @@ from variantworks.utils.stitcher import stitch, decode_consensus
 def create_model():
     """Return neural network to train."""
     # Neural Network
-    rnn = ConsensusRNN(sequence_length=1000, input_feature_size=10, num_output_logits=5)
+    rnn = ConsensusRNN(sequence_length=1000, input_feature_size=10, num_output_logits=5, apply_softmax=True)
 
     return rnn
 

--- a/variantworks/networks.py
+++ b/variantworks/networks.py
@@ -17,6 +17,7 @@
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 
 from nemo.backends.pytorch.nm import TrainableNM
 from nemo.utils.decorators import add_port_docs
@@ -142,19 +143,21 @@ class ConsensusRNN(TrainableNM):
             'output_logit': NeuralType(('B', 'W', 'D'), LogitsType()),
         }
 
-    def __init__(self, sequence_length, input_feature_size, num_output_logits):
+    def __init__(self, sequence_length, input_feature_size, num_output_logits, apply_softmax=False):
         """Construct an Consensus RNN NeMo instance.
 
         Args:
             sequence_length : Length of sequence to feed into RNN.
             input_feature_size : Length of input feature set.
             num_output_logits : Number of output classes of classifier.
+            apply_softmax : Apply softmax to the output of the classifier.
 
         Returns:
             Instance of class.
         """
         super().__init__()
         self.num_output_logits = num_output_logits
+        self.apply_softmax = apply_softmax
 
         self.gru = nn.GRU(input_feature_size, 128, 2, batch_first=True, bidirectional=True)
         self.classifier = nn.Linear(2 * 128, self.num_output_logits)
@@ -174,4 +177,6 @@ class ConsensusRNN(TrainableNM):
         """
         encoding, h_n = self.gru(encoding)
         encoding = self.classifier(encoding)
+        if self.apply_softmax:
+            encoding = F.softmax(encoding, dim=2)
         return encoding


### PR DESCRIPTION
Fixing issue raised in #136 that was causing inference to fail

Root cause of issue is that the softmax was applied twice in the initial version, which was fixed in previous PR. however, that led to an issue where the network output _logits_ instead of probabilities which led to a failure in quality score generation for consensus. This is now fixed by making the call to _softmax_ optional in the networks final layer, so it can be enable for inference only.